### PR TITLE
Switched appengine_config to use site.addsitedir()

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -1,8 +1,8 @@
 """This file is loaded when starting a new application instance."""
-import sys
+import site
 import os.path
 
-# add `lib` subdirectory to `sys.path`, so our `main` module can load
+# add `lib' as a site packages directory, so our `main` module can load
 # third-party libraries.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'lib'))
+site.addsitedir(os.path.join(os.path.dirname(__file__), 'lib'))
 


### PR DESCRIPTION
Replacing sys.path.insert() with site.addsitedir() makes it possible to import namespace package dependencies.
